### PR TITLE
Support discarding keyed areas of image

### DIFF
--- a/src/color_clusters/runner.rs
+++ b/src/color_clusters/runner.rs
@@ -17,6 +17,7 @@ pub struct RunnerConfig {
     pub deepen_diff: i32,
     pub hollow_neighbours: usize,
     pub key_color: Color,
+    pub keying_action: KeyingAction,
 }
 
 impl Default for RunnerConfig {
@@ -32,6 +33,7 @@ impl Default for RunnerConfig {
             deepen_diff: 64,
             hollow_neighbours: 1,
             key_color: Color::default(),
+            keying_action: KeyingAction::default(),
         }
     }
 }
@@ -70,6 +72,7 @@ impl Runner {
             deepen_diff,
             hollow_neighbours,
             key_color,
+            keying_action,
         } = self.config;
 
         assert!(is_same_color_a < 8);
@@ -79,6 +82,7 @@ impl Runner {
             .diagonal(diagonal)
             .hierarchical(hierarchical)
             .key(key_color)
+            .keying_action(keying_action)
             .batch_size(batch_size as u32)
             .same(move |a: Color, b: Color| {
                 color_same(a, b, is_same_color_a, is_same_color_b)

--- a/src/path/util.rs
+++ b/src/path/util.rs
@@ -13,7 +13,7 @@ pub(super) fn signed_area(p1: PointI32, p2: PointI32, p3: PointI32) -> i32 {
 /// https://github.com/tyt2y3/vaser-unity/blob/master/Assets/Vaser/Vec2Ext.cs#L107 (Intersect)
 pub(super) fn find_intersection(p1: &PointF64, p2: &PointF64, p3: &PointF64, p4: &PointF64) -> PointF64 {
 
-    const EPSILON: f64 = f64::EPSILON;
+    const EPSILON: f64 = 1e-7;
     
     let (denom, numera, numerb);
     denom  = (p4.y-p3.y) * (p2.x-p1.x) - (p4.x-p3.x) * (p2.y-p1.y);


### PR DESCRIPTION
Hi there,

I've been working on implementing alpha channel handling in the vtracer CLI (I will make a PR to vtracer soon as well). I followed the instructions given in [this issue](https://github.com/visioncortex/vtracer/issues/8). The first issue I ran into seems to be a regression introduced in version 0.7.0, where an epsilon value was made too small, causing a panic to be triggered with [this sample image](https://user-images.githubusercontent.com/11866496/187427336-2e2ede8b-d9df-4a83-a4de-7461c0afd33a.png) as input. This PR fixes that. It also introduces the notion of a configurable `KeyingAction` which controls what happens when a pixel matching `key_color` is found: `Keep` adds it to the `ZERO` cluster and is the status quo, while `Discard` completely discards it. Let me know what you think.