### PR TITLE
fix panic in stage 2 of color builder

### DIFF
--- a/src/color_clusters/builder.rs
+++ b/src/color_clusters/builder.rs
@@ -403,6 +403,9 @@ impl BuilderImpl {
     }
 
     fn stage_2(&mut self) -> bool {
+        if self.cluster_areas.is_empty() {
+            return true;
+        }
         if self.cluster_areas[self.iteration as usize].count == 0 {
             self.iteration += 1;
             if self.iteration as usize == self.cluster_areas.len() {


### PR DESCRIPTION
We weren't checking to see if `cluster_areas` had any elements before indexing into it, causing panics. Just checking if it's empty beforehand fixes it.